### PR TITLE
Autofix Rails/HttpPositionalArguments deprecations

### DIFF
--- a/test/controllers/microposts_controller_test.rb
+++ b/test/controllers/microposts_controller_test.rb
@@ -20,30 +20,30 @@ class MicropostsControllerTest < ActionController::TestCase
 
   test "should create micropost" do
     assert_difference('Micropost.count') do
-      post :create, micropost: { content: @micropost.content, user_id: @micropost.user_id }
+      post :create, params: { micropost: { content: @micropost.content, user_id: @micropost.user_id } }
     end
 
     assert_redirected_to micropost_path(assigns(:micropost))
   end
 
   test "should show micropost" do
-    get :show, id: @micropost
+    get :show, params: { id: @micropost }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @micropost
+    get :edit, params: { id: @micropost }
     assert_response :success
   end
 
   test "should update micropost" do
-    patch :update, id: @micropost, micropost: { content: @micropost.content, user_id: @micropost.user_id }
+    patch :update, params: { id: @micropost, micropost: { content: @micropost.content, user_id: @micropost.user_id } }
     assert_redirected_to micropost_path(assigns(:micropost))
   end
 
   test "should destroy micropost" do
     assert_difference('Micropost.count', -1) do
-      delete :destroy, id: @micropost
+      delete :destroy, params: { id: @micropost }
     end
 
     assert_redirected_to microposts_path

--- a/test/controllers/microposts_controller_test.rb
+++ b/test/controllers/microposts_controller_test.rb
@@ -20,7 +20,9 @@ class MicropostsControllerTest < ActionController::TestCase
 
   test "should create micropost" do
     assert_difference('Micropost.count') do
-      post :create, params: { micropost: { content: @micropost.content, user_id: @micropost.user_id } }
+      post :create, params: {
+        micropost: { content: @micropost.content, user_id: @micropost.user_id }
+      }
     end
 
     assert_redirected_to micropost_path(assigns(:micropost))
@@ -37,7 +39,11 @@ class MicropostsControllerTest < ActionController::TestCase
   end
 
   test "should update micropost" do
-    patch :update, params: { id: @micropost, micropost: { content: @micropost.content, user_id: @micropost.user_id } }
+    patch :update, params: {
+      id: @micropost, micropost: {
+        content: @micropost.content, user_id: @micropost.user_id
+      }
+    }
     assert_redirected_to micropost_path(assigns(:micropost))
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -20,30 +20,30 @@ class UsersControllerTest < ActionController::TestCase
 
   test "should create user" do
     assert_difference('User.count') do
-      post :create, user: { email: @user.email, name: @user.name }
+      post :create, params: { user: { email: @user.email, name: @user.name } }
     end
 
     assert_redirected_to user_path(assigns(:user))
   end
 
   test "should show user" do
-    get :show, id: @user
+    get :show, params: { id: @user }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @user
+    get :edit, params: { id: @user }
     assert_response :success
   end
 
   test "should update user" do
-    patch :update, id: @user, user: { email: @user.email, name: @user.name }
+    patch :update, params: { id: @user, user: { email: @user.email, name: @user.name } }
     assert_redirected_to user_path(assigns(:user))
   end
 
   test "should destroy user" do
     assert_difference('User.count', -1) do
-      delete :destroy, id: @user
+      delete :destroy, params: { id: @user }
     end
 
     assert_redirected_to users_path

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -37,7 +37,9 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   test "should update user" do
-    patch :update, params: { id: @user, user: { email: @user.email, name: @user.name } }
+    patch :update, params: {
+      id: @user, user: { email: @user.email, name: @user.name }
+    }
     assert_redirected_to user_path(assigns(:user))
   end
 


### PR DESCRIPTION
Run:
```
rubocop -a --only "Rails/HttpPositionalArguments"
```